### PR TITLE
[chore] Add example .spec file to repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,9 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: 🏄 Copy test env vars
+        run: cp .env.example .env
+
       - name: 😻 Setup node
         uses: actions/setup-node@v3
         with:

--- a/app/routes/notes/new.spec.tsx
+++ b/app/routes/notes/new.spec.tsx
@@ -1,0 +1,15 @@
+import {composeStories} from '@storybook/react';
+import {render, screen} from '@testing-library/react';
+import * as stories from './new.stories';
+
+const {Default} = composeStories(stories);
+
+describe('NewNotePage', () => {
+  it('renders two input fields', () => {
+    render(<Default />);
+
+    expect(screen.getByText('Title:')).toBeInTheDocument();
+    expect(screen.getByText('Body:')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+  });
+});

--- a/remix.config.js
+++ b/remix.config.js
@@ -6,6 +6,7 @@ module.exports = {
   ignoredRouteFiles: [
     '**/.*',
     '**/*.css',
+    '**/*.spec.{js,jsx,ts,tsx}',
     '**/*.stories.{js,jsx,ts,tsx}',
     '**/*.test.{js,jsx,ts,tsx}',
   ],

--- a/tests/setup-test-env.ts
+++ b/tests/setup-test-env.ts
@@ -1,4 +1,6 @@
 import {installGlobals} from '@remix-run/node';
+import dotenv from 'dotenv';
 import '@testing-library/jest-dom';
 
 installGlobals();
+dotenv.config(); // Ensure `process.env` variables are defined


### PR DESCRIPTION
## Summary

This PR adds a sample `.spec` file to ensure the following functionality works:
- [x] `.toBeInTheDocument` matchers work
- [x] `composeStories(...)` works with our `<RemixStub />` component
- [x] `.env` file is loaded during tests