### PR TITLE
[chore] Import EDS stylesheets for storybook and use local `<meta>` tags

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,9 @@
 import type {Parameters} from '@storybook/react';
 import '../app/styles/tailwind.css';
 
+import '@chanzuckerberg/eds/lib/tokens/css/variables.css';
+import '@chanzuckerberg/eds/lib/tokens/fonts.css';
+
 export const parameters: Parameters = {
   /**
    * Explicitly set Storybook's background to light because if developers

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -23,12 +23,6 @@ export const links: LinksFunction = () => {
   ];
 };
 
-export const meta: MetaFunction = () => ({
-  charset: 'utf-8',
-  title: 'Edu App',
-  viewport: 'width=device-width,initial-scale=1',
-});
-
 export async function loader({request}: LoaderArgs) {
   return json({
     user: await getUser(request),
@@ -39,6 +33,9 @@ export default function App() {
   return (
     <html className="h-full" lang="en">
       <head>
+        <title>Edu App</title>
+        <meta charSet="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <Meta />
         <Links />
       </head>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,6 @@
 import edsVariablesUrl from '@chanzuckerberg/eds/lib/tokens/css/variables.css';
 import {cssBundleHref} from '@remix-run/css-bundle';
-import type {LinksFunction, LoaderArgs, MetaFunction} from '@remix-run/node';
+import type {LinksFunction, LoaderArgs} from '@remix-run/node';
 import {json} from '@remix-run/node';
 import {
   Links,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,6 @@
 import edsVariablesUrl from '@chanzuckerberg/eds/lib/tokens/css/variables.css';
 import {cssBundleHref} from '@remix-run/css-bundle';
-import type {LinksFunction, LoaderArgs} from '@remix-run/node';
+import type {LinksFunction, LoaderArgs, MetaFunction} from '@remix-run/node';
 import {json} from '@remix-run/node';
 import {
   Links,
@@ -23,6 +23,10 @@ export const links: LinksFunction = () => {
   ];
 };
 
+export const meta: MetaFunction = () => ({
+  title: 'Edu App',
+});
+
 export async function loader({request}: LoaderArgs) {
   return json({
     user: await getUser(request),
@@ -33,7 +37,6 @@ export default function App() {
   return (
     <html className="h-full" lang="en">
       <head>
-        <title>Edu App</title>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <Meta />


### PR DESCRIPTION
### Summary:

<!--
  Describe your changes and any relevant context.
-->

1) Importing EDS stylesheets as called out by the [eds/README.md](https://github.com/chanzuckerberg/edu-design-system/blob/next/README.md) (*we're already doing this in the GST repo*)
2) Opting to use `<meta>` instead of `export const meta` in `app/root.tsx` after reading the Remix docs.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] `npm run dev` and `npm run storybook` still run locally and load pages correctly
